### PR TITLE
Chatbot 279 fix long titles

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_card.html
+++ b/frappe/public/js/frappe/views/kanban/kanban_card.html
@@ -8,7 +8,7 @@
 		<div class="kanban-card-body">
 			<div class="kanban-title-area">
 				<a href="{{ form_link }}">
-					<div class="kanban-card-title ellipsis">
+					<div class="kanban-card-title">
 						{{ title }}
 					</div>
 				</a>

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -30,7 +30,8 @@
 		flex: 0 0 200px;
 		max-width: 200px;
 		border-radius: var(--border-radius);
-		padding: var(--padding-md);
+		padding-top: 0px;
+		padding: var(--padding-sm);
 		min-height: calc(100vh - 150px);
 		max-height: calc(100vh - var(--navbar-height) - var(--page-bottom-margin) - 80px);
 
@@ -72,7 +73,6 @@
 		.kanban-column-header {
 			@include flex(flex, space-between, null, null);
 			margin-top: 0;
-			margin-bottom: 15px;
 			position: relative;
 			font-weight: 500;
 			font-size: 12px;
@@ -158,7 +158,7 @@
 				}
 				.kanban-card {
 					@include flex(flex, space-between, null, column);
-					margin-top: var(--margin-sm);
+					margin-top: var(--margin-xs);
 					min-height: 100px;
 					@include card(
 						$padding: 0,

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -27,8 +27,8 @@
 	.kanban-column {
 		@include transition();
 
-		flex: 0 0 260px;
-		max-width: 260px;
+		flex: 0 0 200px;
+		max-width: 200px;
 		border-radius: var(--border-radius);
 		padding: var(--padding-md);
 		min-height: calc(100vh - 150px);

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -193,6 +193,16 @@
 							background: whitesmoke;
 							padding: .2em .5em;
 
+							.kanban-card-title {
+								-webkit-box-orient: vertical;
+								display: block;
+								display: -webkit-box;
+								-webkit-line-clamp: 2;
+								line-clamp: 2;
+								overflow: hidden;
+								text-overflow: ellipsis;
+							}
+
 							.kanban-card-doc {
 								.text-muted div {
 									display: inline;


### PR DESCRIPTION
This PR fixed the issue of long titles of job cards in the Kanban view by ensuring they are displayed on two lines and update card spacing.

- Update styles for columns
- Add styles for detach long card title in two lines



