### PR TITLE
fix: correct Project kanban queue ordering with two-block sort

### DIFF
--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -354,6 +354,28 @@ def get_order_for_column(board, colname):
 
 
 @frappe.whitelist()
+def get_kanban_board(board_name):
+    """Fetch a Kanban Board for rendering.
+
+    For Project boards, rebuild each column's `order` on the fly from the current
+    queue_position / appointment_date instead of the order frozen at board creation
+    (before_insert) or last drag. This is in-memory only (no save), so every load
+    reflects live data without writing on read.
+    """
+    board = frappe.get_doc("Kanban Board", board_name)
+    board.check_permission("read")
+
+    if board.reference_doctype == "Project":
+        projects_ordered = get_projects_ordered_by_queue_position_and_appointment_date()
+        for column in board.columns:
+            column.order = frappe.as_json(
+                [p["name"] for p in projects_ordered if p.get("status") == column.column_name]
+            )
+
+    return board.as_dict()
+
+
+@frappe.whitelist()
 def update_column_order(board_name, order):
     """Set the order of columns in Kanban Board"""
     board = frappe.get_doc("Kanban Board", board_name)
@@ -501,7 +523,7 @@ _QUEUE_CACHE_TTL = 5  # seconds
 
 def get_projects_ordered_by_queue_position_and_appointment_date():
     """Get projects in two independent blocks, split by appointment_date presence:
-    first the ones WITHOUT appointment_date (ordered by queue_position DESC; rows without
+    first the ones WITHOUT appointment_date (ordered by queue_position ASC; rows without
     queue_position last), then the ones WITH appointment_date (ordered by appointment_date ASC).
     Each block uses its own sort key; one never breaks ties for the other."""
     cached = frappe.cache().get_value(_QUEUE_CACHE_KEY)
@@ -515,11 +537,11 @@ def get_projects_ordered_by_queue_position_and_appointment_date():
         has_date = "CASE WHEN appointment_date IS NULL THEN 0 ELSE 1 END AS has_date"
 
         # queue_position (numeric) orders ONLY the "no appointment_date" block.
-        # NULL/empty/0 queue_position is mapped to -1 so it lands last under DESC.
+        # NULL/empty/0 queue_position is mapped to 999999 so it lands last under ASC.
         # It is NULL for the dated block, so it never breaks the appointment_date order.
         queue_sort = (
             "CASE WHEN appointment_date IS NULL THEN "
-            f"(CASE WHEN {_no_queue} THEN -1 ELSE CAST(queue_position AS DECIMAL(20,0)) END) "
+            f"(CASE WHEN {_no_queue} THEN 999999 ELSE CAST(queue_position AS DECIMAL(20,0)) END) "
             "ELSE NULL END AS queue_sort"
         )
 
@@ -538,7 +560,7 @@ def get_projects_ordered_by_queue_position_and_appointment_date():
             filters={
                 "status": ["in", ["In queue", "In parking"]],
             },
-            order_by="has_date ASC, queue_sort DESC, appointment_date ASC",
+            order_by="has_date ASC, queue_sort ASC, appointment_date ASC",
         )
 
         frappe.cache().set_value(_QUEUE_CACHE_KEY, projects, expires_in_sec=_QUEUE_CACHE_TTL)

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -134,8 +134,20 @@ def execute(doctype, *args, **kwargs):
 
         kwargs["fields"] = fields
 
-        # Forzar el orden deseado SIEMPRE para Project
-        kwargs["order_by"] = "queue_position_num ASC, appointment_date ASC"
+        # Forzar el orden deseado SIEMPRE para Project, en DOS bloques independientes:
+        #   1) sin appointment_date  -> ordenados por queue_position ASC (sin posición, al final)
+        #   2) con appointment_date  -> ordenados por appointment_date ASC
+        # El segundo término neutraliza queue_position en el bloque con fecha (constante 0),
+        # para que una card con fecha que además tenga queue_position no se cuele en la cola.
+        queue_order = (
+            "CASE WHEN queue_position IS NULL OR queue_position = '' OR queue_position = 0 "
+            "THEN 999999 ELSE CAST(queue_position AS DECIMAL(20,0)) END"
+        )
+        kwargs["order_by"] = (
+            "(CASE WHEN appointment_date IS NULL THEN 0 ELSE 1 END) ASC, "
+            f"(CASE WHEN appointment_date IS NULL THEN {queue_order} ELSE 0 END) ASC, "
+            "appointment_date ASC"
+        )
 
     # Permisos
     kwargs["ignore_permissions"] = kwargs.get("ip", False) == "1"

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -158,13 +158,21 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	get_board() {
-		return frappe.db.get_doc("Kanban Board", this.board_name).then((board) => {
-			this.board = board;
-			this.board.filters_array = JSON.parse(this.board.filters || "[]");
-			this.board.fields = JSON.parse(this.board.fields || "[]");
-			this.board.card_fields = JSON.parse(this.board.card_fields || "[]");
-			this.filters = this.board.filters_array;
-		});
+		// Use the custom endpoint so Project boards get their column order rebuilt
+		// from live queue_position / appointment_date on every load (frappe.db.get_doc
+		// would return the frozen, possibly stale, stored order).
+		return frappe
+			.call("frappe.desk.doctype.kanban_board.kanban_board.get_kanban_board", {
+				board_name: this.board_name,
+			})
+			.then((r) => {
+				const board = r.message;
+				this.board = board;
+				this.board.filters_array = JSON.parse(this.board.filters || "[]");
+				this.board.fields = JSON.parse(this.board.fields || "[]");
+				this.board.card_fields = JSON.parse(this.board.card_fields || "[]");
+				this.filters = this.board.filters_array;
+			});
 	}
 
 	setup_page() {


### PR DESCRIPTION
Queue/parking columns now render in two independent blocks: cards without appointment_date sorted by queue_position ASC (no-position last), then cards with appointment_date sorted by appointment_date ASC.

Root cause was stale column.order: the rendered within-column order comes from the Kanban Board column.order JSON, which was only built at board creation and on drag, so it never reflected later queue_position/appointment_date changes.

- reportview.py: forced order_by now splits into the two blocks and neutralizes queue_position inside the dated block so dated cards don't leak into the queue
- kanban_board.py: queue_sort DESC->ASC and no-position sentinel -1->999999
- kanban_board.py: add get_kanban_board endpoint that rebuilds column.order in-memory per load for Project boards
- kanban_view.js: get_board() uses the new endpoint (frappe.db.get_doc bypasses onload, so per-load recompute must go through a whitelisted endpoint)

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
