### PR TITLE
fix(kanban): wait for bundle before instantiating KanbanBoard

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -332,20 +332,27 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 
 	render() {
 		const board_name = this.board_name;
-		if (!this.kanban) {
-			this.kanban = new frappe.views.KanbanBoard({
-				doctype: this.doctype,
-				board: this.board,
-				board_name: board_name,
-				cards: this.data,
-				card_meta: this.card_meta,
-				wrapper: this.$result,
-				cur_list: this,
-				user_settings: this.view_user_settings,
-			});
-		} else if (board_name === this.kanban.board_name) {
-			this.kanban.update(this.data);
-		}
+		// `frappe.views.KanbanBoard` is defined by kanban_board.bundle.js, which loads
+		// in parallel with the board data fetch. If the data fetch wins the race the
+		// bundle may not be ready yet, so gate rendering on `load_lib` to guarantee the
+		// constructor exists before we call it (fixes intermittent
+		// "frappe.views.KanbanBoard is not a constructor").
+		this.load_lib.then(() => {
+			if (!this.kanban) {
+				this.kanban = new frappe.views.KanbanBoard({
+					doctype: this.doctype,
+					board: this.board,
+					board_name: board_name,
+					cards: this.data,
+					card_meta: this.card_meta,
+					wrapper: this.$result,
+					cur_list: this,
+					user_settings: this.view_user_settings,
+				});
+			} else if (board_name === this.kanban.board_name) {
+				this.kanban.update(this.data);
+			}
+		});
 	}
 
 


### PR DESCRIPTION
Gate the KanbanBoard instantiation on this.load_lib so the render path cannot run new frappe.views.KanbanBoard() before kanban_board.bundle.js has loaded. Fixes intermittent 'frappe.views.KanbanBoard is not a constructor' where the board data fetch wins the race against the bundle load and the board silently fails to render.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
